### PR TITLE
Improve cross-arch bash setup

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,7 +1,10 @@
 # -------------------------------
 # Homebrew 配置
 # -------------------------------
-eval "$(/opt/homebrew/bin/brew shellenv)"
+BREW_CMD="$(command -v brew)"
+if [ -n "$BREW_CMD" ]; then
+  eval "$($BREW_CMD shellenv)"
+fi
 
 # 如果存在 .bashrc，则加载它
 if [ -f ~/.bashrc ]; then

--- a/.bashrc
+++ b/.bashrc
@@ -38,18 +38,21 @@ export PATH="$HOME/bin:$PATH"
 # bash-completion（如果安装了的话）
 # -------------------------------
 
-if [ -f /opt/homebrew/etc/bash_completion ]; then
-  source /opt/homebrew/etc/bash_completion
+if command -v brew >/dev/null; then
+  HOMEBREW_PREFIX="$(brew --prefix)"
+  if [ -f "$HOMEBREW_PREFIX/etc/bash_completion" ]; then
+    source "$HOMEBREW_PREFIX/etc/bash_completion"
+  fi
+  export PATH="$HOMEBREW_PREFIX/bin:$PATH"
+  export PATH="$HOMEBREW_PREFIX/opt/mysql-client/bin:$PATH"
+  export PKG_CONFIG_PATH="$HOMEBREW_PREFIX/opt/mysql-client/lib/pkgconfig"
 fi
 
 alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 export PATH="$PATH:/Applications/Tailscale.app/Contents/MacOS"
-export PATH="/opt/homebrew/bin:$PATH"
 
 export LANG=zh_CN.UTF-8
 export LC_ALL=zh_CN.UTF-8
 
-export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
-export PKG_CONFIG_PATH="/opt/homebrew/opt/mysql-client/lib/pkgconfig"
 export MYSQLCLIENT_CFLAGS=$(pkg-config --cflags mysqlclient)
 export MYSQLCLIENT_LDFLAGS=$(pkg-config --libs mysqlclient)

--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@
    sh install.sh
    ```
 
-3. Restart your terminal or run:
-   ```
-   exec /opt/homebrew/bin/bash -l
-   ```
+3. Restart your terminal or run the following to launch the Homebrew Bash.
+   This works on both Apple Silicon and Intel Macs:
+   ```bash
+exec "$(brew --prefix)"/bin/bash -l
+```
+
+## Cross-platform notes
+
+Homebrew installs packages under different prefixes depending on your Mac's
+architecture (`/opt/homebrew` for Apple Silicon and `/usr/local` for Intel).
+All scripts in this repo use `#!/usr/bin/env bash` and rely on `brew --prefix`
+so the same commands work on both types of machines.
 
 ## Requirements
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Color definitions
 RESET="\033[0m"
@@ -36,7 +36,7 @@ eval "$($BREW_CMD shellenv)"
 HOMEBREW_BASH_PATH=$($BREW_CMD --prefix)/bin/bash
 
 # Check if any sudo operations will be needed and cache credentials upfront
-current_shell=$(dscl . -read /Users/$USER UserShell | awk '{print $2}')
+current_shell=$(dscl . -read /Users/"$USER" UserShell | awk '{print $2}')
 if [[ "$current_shell" != "$HOMEBREW_BASH_PATH" ]] || ! grep -q "$HOMEBREW_BASH_PATH" /etc/shells; then
   info "Administrator privileges will be required for shell setup"
   sudo -v
@@ -65,7 +65,7 @@ fi
 # Set as default shell if needed
 if [[ "$current_shell" != "$HOMEBREW_BASH_PATH" ]]; then
   info "Setting Homebrew's Bash as default shell..."
-  sudo chsh -s "$HOMEBREW_BASH_PATH" $USER
+  sudo chsh -s "$HOMEBREW_BASH_PATH" "$USER"
   success "Default shell changed"
 else
   success "Homebrew's Bash already set as default shell"


### PR DESCRIPTION
## Summary
- use `/usr/bin/env bash` shebang
- detect Homebrew path in `.bash_profile` and `.bashrc`
- document universal Homebrew paths in README
- quote `$USER` in `install.sh`

## Testing
- `shellcheck install.sh`
- `shellcheck .bashrc`

------
https://chatgpt.com/codex/tasks/task_e_684ddeef40648330ae9110cba1f265bc