### PR TITLE
Add Homebrew PATH entries

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -32,6 +32,16 @@ alias ...="cd ../.."
 # PATH 扩展（示例：添加 ~/bin 目录）
 # -------------------------------
 
+# Add common Homebrew locations so `brew` works even if they are not already
+# in PATH. This covers Apple Silicon Macs (`/opt/homebrew`) and Intel Macs
+# (`/usr/local`).
+if [ -d "/opt/homebrew/bin" ]; then
+  export PATH="/opt/homebrew/bin:$PATH"
+fi
+if [ -d "/usr/local/bin" ]; then
+  export PATH="/usr/local/bin:$PATH"
+fi
+
 export PATH="$HOME/bin:$PATH"
 
 # -------------------------------

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ architecture (`/opt/homebrew` for Apple Silicon and `/usr/local` for Intel).
 All scripts in this repo use `#!/usr/bin/env bash` and rely on `brew --prefix`
 so the same commands work on both types of machines.
 
+Your `.bashrc` also automatically adds `/opt/homebrew/bin` and `/usr/local/bin`
+to `PATH` if they exist. This guarantees that `brew` and packages installed by
+Homebrew are found regardless of architecture.
+
 ## Requirements
 
 - macOS


### PR DESCRIPTION
## Summary
- support `/opt/homebrew/bin` and `/usr/local/bin` in `.bashrc`
- document how PATH entries are added for both architectures

## Testing
- `shellcheck install.sh .bashrc .bash_profile`
- `sh -n install.sh && sh -n .bashrc && sh -n .bash_profile`

------
https://chatgpt.com/codex/tasks/task_e_684de1042594833089b1ded500aedcef